### PR TITLE
Allow Zipkin Trace Level Two

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Zipkin headers to the IRONdb nodes that are being queried.
 `IRONDB_ZIPKIN_ENABLED` is set to False, this flag will do nothing. If it
 is set to True, this will send headers to the IRONdb nodes that will
 enable additional event tracing. Right now, the only acceptable values
-are `0` (off) and `1` (basic tracing).
+are `0` (off), `1` (basic tracing), and `2` (detailed tracing). `2` can
+potentially cause performance issues - use this level sparingly. Only
+recommended for when trying to debug something specific.
 
 Changelog
 ---------

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -217,7 +217,6 @@ class IRONdbMeasurementFetcher(object):
                             traceheader = binascii.hexlify(os.urandom(8))
                             send_headers['X-B3-TraceId'] = traceheader
                             send_headers['X-B3-SpanId'] = traceheader
-                            send_headers['X-B3-Sampled'] = '1'
                             if self.zipkin_event_trace_level == 1:
                                 send_headers['X-Mtev-Trace-Event'] = '1'
                             elif self.zipkin_event_trace_level == 2:
@@ -346,7 +345,6 @@ class IRONdbFinder(BaseFinder):
                         traceheader = binascii.hexlify(os.urandom(8))
                         name_headers['X-B3-TraceId'] = traceheader
                         name_headers['X-B3-SpanId'] = traceheader
-                        name_headers['X-B3-Sampled'] = '1'
                         if self.zipkin_event_trace_level == 1:
                             name_headers['X-Mtev-Trace-Event'] = '1'
                         if self.zipkin_event_trace_level == 2:
@@ -438,7 +436,6 @@ class IRONdbFinder(BaseFinder):
                     traceheader = binascii.hexlify(os.urandom(8))
                     name_headers['X-B3-TraceId'] = traceheader
                     name_headers['X-B3-SpanId'] = traceheader
-                    name_headers['X-B3-Sampled'] = '1'
                     if self.zipkin_event_trace_level == 1:
                         name_headers['X-Mtev-Trace-Event'] = '1'
                     elif self.zipkin_event_trace_level == 2:
@@ -514,7 +511,6 @@ class IRONdbTagFetcher(BaseTagDB):
                     traceheader = binascii.hexlify(os.urandom(8))
                     tag_headers['X-B3-TraceId'] = traceheader
                     tag_headers['X-B3-SpanId'] = traceheader
-                    tag_headers['X-B3-Sampled'] = '1'
                     if self.zipkin_event_trace_level == 1:
                         tag_headers['X-Mtev-Trace-Event'] = '1'
                     elif self.zipkin_event_trace_level == 2:

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -162,11 +162,11 @@ class IRONdbLocalSettings(object):
                     # Somebody tried to get cute, just disable it
                     log.info("Can't set IRONDB_ZIPKIN_EVENT_TRACE_LEVEL below zero, setting to zero\n")
                     self.zipkin_event_trace_level = 0
-                elif self.zipkin_event_trace_level > 1:
+                elif self.zipkin_event_trace_level > 2:
                     # We only support level 1 for now... may add support
                     # for higher levels later
-                    log.info("Can't set IRONDB_ZIPKIN_EVENT_TRACE_LEVEL above one, setting to one\n")
-                    self.zipkin_event_trace_level = 1
+                    log.info("Can't set IRONDB_ZIPKIN_EVENT_TRACE_LEVEL above two... setting to two\n")
+                    self.zipkin_event_trace_level = 2
             else:
                 self.zipkin_event_trace_level = 0
         except AttributeError:
@@ -219,6 +219,8 @@ class IRONdbMeasurementFetcher(object):
                             send_headers['X-B3-SpanId'] = traceheader
                             if self.zipkin_event_trace_level == 1:
                                 send_headers['X-Mtev-Trace-Event'] = '1'
+                            elif self.zipkin_event_trace_level == 2:
+                                send_headers['X-Mtev-Trace-Event'] = '2'
                         d = requests.post(urls.series_multi, json = params, headers = send_headers,
                                           timeout=((self.connection_timeout / 1000), (self.timeout / 1000)))
                         d.raise_for_status()
@@ -345,6 +347,8 @@ class IRONdbFinder(BaseFinder):
                         name_headers['X-B3-SpanId'] = traceheader
                         if self.zipkin_event_trace_level == 1:
                             name_headers['X-Mtev-Trace-Event'] = '1'
+                        if self.zipkin_event_trace_level == 2:
+                            name_headers['X-Mtev-Trace-Event'] = '2'
                     r = requests.get(node, params={'query': pattern}, headers=name_headers,
                                      timeout=((self.connection_timeout / 1000), (self.timeout / 1000)))
                     r.raise_for_status()
@@ -434,6 +438,8 @@ class IRONdbFinder(BaseFinder):
                     name_headers['X-B3-SpanId'] = traceheader
                     if self.zipkin_event_trace_level == 1:
                         name_headers['X-Mtev-Trace-Event'] = '1'
+                    elif self.zipkin_event_trace_level == 2:
+                        name_headers['X-Mtev-Trace-Event'] = '2'
                 r = requests.get(urls.names, params={'query': query.pattern}, headers=name_headers,
                                  timeout=((self.connection_timeout / 1000), (self.timeout / 1000)))
                 r.raise_for_status()
@@ -507,6 +513,8 @@ class IRONdbTagFetcher(BaseTagDB):
                     tag_headers['X-B3-SpanId'] = traceheader
                     if self.zipkin_event_trace_level == 1:
                         tag_headers['X-Mtev-Trace-Event'] = '1'
+                    elif self.zipkin_event_trace_level == 2:
+                        tag_headers['X-Mtev-Trace-Event'] = '2'
                 r = requests.get(url, params=query, headers=tag_headers,
                                      timeout=((self.connection_timeout / 1000), (self.timeout / 1000)))
                 r.raise_for_status()

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -217,6 +217,7 @@ class IRONdbMeasurementFetcher(object):
                             traceheader = binascii.hexlify(os.urandom(8))
                             send_headers['X-B3-TraceId'] = traceheader
                             send_headers['X-B3-SpanId'] = traceheader
+                            send_headers['X-B3-Sampled'] = '1'
                             if self.zipkin_event_trace_level == 1:
                                 send_headers['X-Mtev-Trace-Event'] = '1'
                             elif self.zipkin_event_trace_level == 2:
@@ -345,6 +346,7 @@ class IRONdbFinder(BaseFinder):
                         traceheader = binascii.hexlify(os.urandom(8))
                         name_headers['X-B3-TraceId'] = traceheader
                         name_headers['X-B3-SpanId'] = traceheader
+                        name_headers['X-B3-Sampled'] = '1'
                         if self.zipkin_event_trace_level == 1:
                             name_headers['X-Mtev-Trace-Event'] = '1'
                         if self.zipkin_event_trace_level == 2:
@@ -436,6 +438,7 @@ class IRONdbFinder(BaseFinder):
                     traceheader = binascii.hexlify(os.urandom(8))
                     name_headers['X-B3-TraceId'] = traceheader
                     name_headers['X-B3-SpanId'] = traceheader
+                    name_headers['X-B3-Sampled'] = '1'
                     if self.zipkin_event_trace_level == 1:
                         name_headers['X-Mtev-Trace-Event'] = '1'
                     elif self.zipkin_event_trace_level == 2:
@@ -511,6 +514,7 @@ class IRONdbTagFetcher(BaseTagDB):
                     traceheader = binascii.hexlify(os.urandom(8))
                     tag_headers['X-B3-TraceId'] = traceheader
                     tag_headers['X-B3-SpanId'] = traceheader
+                    tag_headers['X-B3-Sampled'] = '1'
                     if self.zipkin_event_trace_level == 1:
                         tag_headers['X-Mtev-Trace-Event'] = '1'
                     elif self.zipkin_event_trace_level == 2:


### PR DESCRIPTION
We should allow users to select Zipkin trace level two. It can cause
performance issues if run - added a warning in the README that describes
the flag.