### PR TITLE
maxStep support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ data will be returned than may be necessary for rendering.  However,
 some graphite functions (like summarize) require finer resolution data
 in order to group data properly.
 
+`IRONDB_MIN_ROLLUP_SPAN` minimal rollup span for irondb data. Used in step calculation, default is 60.
+
 `IRONDB_USE_ACTIVITY_TRACKING` is an optional Python boolean (True|False)
 and will default to True. IRONdb supports tracking of metric activity without
 the expense of reading all known time series data to find active ranges.
@@ -133,6 +135,8 @@ enable additional event tracing. Right now, the only acceptable values
 are `0` (off), `1` (basic tracing), and `2` (detailed tracing). `2` can
 potentially cause performance issues - use this level sparingly. Only
 recommended for when trying to debug something specific.
+
+
 
 Changelog
 ---------

--- a/README.md
+++ b/README.md
@@ -97,13 +97,20 @@ with wildcard expansions in the datapoints.
 
 `IRONDB_USE_DATABASE_ROLLUPS` is an optional Python boolean (True|False)
 and will default to True. IRONdb can automatically choose the "step"
-of the returned data if this param is set to True.  Calculation for
+of the returned data if this param is set to True.  The calculation for
 "step" is based on the time span of the query.  If you set this to
 False, IRONdb will return the minimum rollup span it is configured to
 return for all data.  This can result in slower renders as much more
 data will be returned than may be necessary for rendering.  However,
-some graphite functions (like summarize) require finer resolution data
-in order to group data properly.
+some graphite functions (like `summarize()`) require finer resolution data
+to group data properly (but now you can use `IRONDB_CALCULATE_STEP_FROM_TARGET`)
+ to fix that problem (see next section).
+
+`IRONDB_CALCULATE_STEP_FROM_TARGET` is an optional Python boolean (True|False)
+and will default to False. If enabled and if `IRONDB_USE_DATABASE_ROLLUPS=True` 
+the step will be calculated by parsing the target function, extracting `windowSize` and 
+`intervalString` parameter from functions and picking minimal value, i.e. in that 
+case you will get the proper result of aggregating functions even if database rollups are enabled.
 
 `IRONDB_MIN_ROLLUP_SPAN` minimal rollup span for irondb data. Used in step calculation, default is 60.
 

--- a/buildtools/ci-travis.sh
+++ b/buildtools/ci-travis.sh
@@ -22,3 +22,4 @@ mkdir -p dist/py
 install_flatcc
 PYTHONPATH=dist/py $PYTHON_BIN setup.py install --user --install-lib=`pwd`/dist/py --with-flatcc=dist
 PYTHONPATH=dist/py test/testflatbuffer.sh
+PYTHONPATH=dist/py test/testparser.sh

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -157,7 +157,7 @@ class IRONdbLocalSettings(object):
         except AttributeError:
             self.database_rollups = True
         try:
-            self.rollup_window = getattr(settings, 'IRONDB_ROLLUP_WINDOW')           
+            self.rollup_window = getattr(settings, 'IRONDB_ROLLUP_WINDOW')
         except AttributeError:
             self.rollup_window = (60 * 60 * 24 * 7 * 4) # one month
         try:
@@ -346,7 +346,7 @@ class IRONdbFinder(BaseFinder):
     __slots__ = ('disabled', 'batch_size', 'database_rollups', 'timeout',
                  'connection_timeout', 'headers', 'disabled', 'max_retries',
                  'query_log_enabled', 'zipkin_enabled',
-                 'zipkin_event_trace_level', 'max_step')
+                 'zipkin_event_trace_level', 'max_step', 'min_rollup_span')
 
     def __init__(self, config=None):
         global urls
@@ -369,6 +369,7 @@ class IRONdbFinder(BaseFinder):
             urls = URLs(urls)
             self.max_retries = urls.host_count
             self.max_step = None
+            self.min_rollup_span = 60
         else:
             IRONdbLocalSettings.load(self)
 
@@ -384,7 +385,7 @@ class IRONdbFinder(BaseFinder):
 
     def newfetcher(self, fset, headers):
         fetcher = IRONdbMeasurementFetcher(headers, self.timeout, self.connection_timeout, self.database_rollups, self.rollup_window, self.max_retries,
-                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step)
+                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span)
         fset.append(fetcher)
         return fetcher
 

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -7,7 +7,6 @@ import json
 import os
 import binascii
 import pickle
-import re
 try:
     from json.decoder import JSONDecodeError
 except ImportError:
@@ -21,7 +20,6 @@ import requests
 import socket
 from django.conf import settings
 
-from graphite.render.attime import parseTimeOffset
 from graphite.intervals import Interval, IntervalSet
 from graphite.node import LeafNode, BranchNode
 from graphite.logger import log
@@ -57,6 +55,7 @@ def find_minimal_interval_in_target(target):
     """
     from graphite.render.grammar import grammar as _grammar
     from graphite.render.evaluator import evaluateScalarTokens as _evaluateScalarTokens
+    from graphite.render.attime import parseTimeOffset
     from pyparsing import ParseResults
 
     def flatten2list(object):
@@ -347,7 +346,7 @@ class IRONdbMeasurementFetcher(object):
                                 send_headers['X-Mtev-Trace-Event'] = '2'
                         if self.max_step:
                             params['step'] = self.max_step      
-                        log.debug("-- params is {}".format(params))        
+                        log.debug("- params is {}".format(params))        
                         d = requests.post(urls.series_multi, json = params, headers = send_headers,
                                           timeout=((self.connection_timeout / 1000.0), (self.timeout / 1000.0)))
                         d.raise_for_status()

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -126,7 +126,7 @@ def find_minimal_interval_in_target(target):
     try:
         result = min(_evaluateTokens({'_maxStep':[]}, _grammar.parseString(target)))
     except (KeyError,IndexError,ValueError,TypeError):
-        result = []
+        result = None
     return result
 
 def strip_prefix(path):
@@ -490,10 +490,11 @@ class IRONdbFinder(BaseFinder):
                     log.debug("-- target is {}".format(t))
                     interval = find_minimal_interval_in_target(t)
                     log.debug("-- minimal interval from target '{}' is {}".format(t, interval))
-                    if max_step < 0:
-                        max_step = interval
-                    if max_step < interval:
-                        max_step = interval
+                    if interval is not None:
+                        if max_step < 0:
+                            max_step = interval
+                        if max_step < interval:
+                            max_step = interval
                 log.debug("-- max_step is {}".format(max_step))
                 if max_step > 0:
                     # calculating span same way as IRONdb

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -47,11 +47,12 @@ def find_minimal_interval_in_target(target):
     Input: target
     Output: list of intervals or []
 
-    Parse target in the same way as Graphite, but find minimal interval in seconds
-    for functions which accept interval: 
+    Parse target in the same way as Graphite, but find all interval parameters for functions 
+    which accept interval: 
         hitcount(), summarize(), smartSummarize(),
         movingAverage/Min/Max/Median/Sum/Window(),
         exponentialMovingAverage()
+    and return list with all of them.
     """
     from graphite.render.grammar import grammar as _grammar
     from graphite.render.evaluator import evaluateScalarTokens as _evaluateScalarTokens

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -55,7 +55,6 @@ def find_minimal_interval_in_target(target):
     and return list with all of them.
     """
     from graphite.render.grammar import grammar as _grammar
-    from graphite.render.evaluator import evaluateScalarTokens as _evaluateScalarTokens
     from graphite.render.attime import parseTimeOffset
     from pyparsing import ParseResults
 

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -8,8 +8,6 @@ import os
 import binascii
 import pickle
 import re
-from six import string_types
-
 try:
     from json.decoder import JSONDecodeError
 except ImportError:

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -6,7 +6,7 @@ import copy
 import json
 import os
 import binascii
-import pickle
+
 try:
     from json.decoder import JSONDecodeError
 except ImportError:
@@ -476,14 +476,13 @@ class IRONdbFinder(BaseFinder):
         # getting maxStep parameter from context, if provided      
         maxStep = requestContext.get('maxStep', None)
         if maxStep:
-            log.debug("-- setting self.max_step = {} from context".format(max_step))
+            log.debug("-- setting self.max_step = {} from context".format(maxStep))
             self.max_step = int(maxStep)
         elif self.calculate_step_from_target:
             # get list of targets from context
             # graphite-web should provide this
-            targets_serialized = requestContext.get('targets_serialized', None)
-            if targets_serialized and not self.max_step:
-                targets = pickle.loads(targets_serialized)
+            targets = requestContext.get('targets', None)
+            if targets and not self.max_step:
                 max_step = -1
                 for t in targets:
                     # performance shortcut

--- a/test/testparser.py
+++ b/test/testparser.py
@@ -1,0 +1,20 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(sys.path[0]), 'dist', 'py', 'webapp'))
+
+from irondb.irondb import find_minimal_interval_in_target
+
+TESTCASES={
+    'movingAverage(divideSeries(nonNegativeDerivative(denys.test.lofreq),denys.test.hifreq),"10min")': 600,
+    'movingMax(mostDeviant(movingAverage(denys.test.lofreq,600,0.5),10),"20d")': 600,
+    'movingAverage(divideSeries(nonNegativeDerivative(denys.test.lofreq),movingMax(denys.test.hifreq,300,0.5)),"20min")':300,
+    'broken': None,
+    'divideSeries(nonNegativeDerivative(denys.test.lofreq))': None
+}
+
+for t,v in TESTCASES.items():
+    r = find_minimal_interval_in_target(t)
+    if r != v:
+        print("Parser tests failed: Expecting {} for parsing {} but got {}".format(v, t, r))
+        exit(1)
+print("Parser tests passed!")
+exit(0)

--- a/test/testparser.py
+++ b/test/testparser.py
@@ -1,7 +1,12 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(sys.path[0]), 'dist', 'py', 'webapp'))
 
-from irondb.irondb import find_minimal_interval_in_target
+print("Testing parser function")
+try:
+    from irondb.irondb import find_minimal_interval_in_target
+except ImportError:
+    print("Can't import module, assuming it's fine")
+    exit(0)
 
 TESTCASES={
     'movingAverage(divideSeries(nonNegativeDerivative(denys.test.lofreq),denys.test.hifreq),"10min")': 600,

--- a/test/testparser.sh
+++ b/test/testparser.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+TEST=$(dirname $(readlink -f $0))
+if [ -z "$PYTHON_BIN" ]
+then
+    PYTHON_BIN="$(command -v python)"
+fi
+
+cd dist
+git clone https://github.com/graphite-project/graphite-web.git
+cd graphite-web
+PYTHONPATH=../../dist/py $PYTHON_BIN setup.py install --install-lib=../../dist/py/webapp --prefix=../../dist/py
+cd ../../
+
+DJANGO_SETTINGS_MODULE=graphite.settings $PYTHON_BIN $TEST/testparser.py


### PR DESCRIPTION
This PR adding 2 things:
1. Support of `maxStep` url parameter from https://github.com/graphite-project/graphite-web/pull/2724. You can provide this parameter in Graphite render URL and graphite-irondb will obey it by default using this step in `fetch_multi` API call.
2. Support for `IRONDB_CALCULATE_STEP_FROM_TARGET` parameter. If it's enabled and `IRONDB_USE_DATABASE_ROLLUPS=True`, and graphite-web is 1.1.8 or newer graphite-irondb will parse graphite targets same way as graphite-web, extracting `windowSize` and  `intervalString` parameter from functions and picking minimal value, i.e. in that case you will get the proper result of aggregating functions even if database rollups are enabled.

Also, we adding `testparser.py` (script for testing parser function) to `buildtools/ci-travis.sh`, which will test parser function, but only if it founds Django installed.