### PR TITLE
Graphite_adjust_step.json support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ case you will get the proper result of aggregating functions even if database ro
 
 `IRONDB_MIN_ROLLUP_SPAN` minimal rollup span for irondb data. Used in step calculation, default is 60.
 
+`IRONDB_GRAPHITE_ADJUST_STEP_URL` - url to `graphite_adjust_step.json` file. If present - metrics will be grouped during retrieve phase by step parameter, so, IronDB would return preper results. If empty or not retrieavable
+then grouping functionality will be disabled.
+
+`IRONDB_GRAPHITE_ADJUST_STEP_URL_TTL` - number of seconds to cache content of retrieved `graphite_adjust_step.json` file. Default is 900 (15 munutes). If refresh attempt is unsuccessful it will disable grouping functionality until next successful retrieve attepmpt.
+
 `IRONDB_USE_ACTIVITY_TRACKING` is an optional Python boolean (True|False)
 and will default to True. IRONdb supports tracking of metric activity without
 the expense of reading all known time series data to find active ranges.

--- a/README.md
+++ b/README.md
@@ -115,10 +115,9 @@ case you will get the proper result of aggregating functions even if database ro
 
 `IRONDB_MIN_ROLLUP_SPAN` minimal rollup span for irondb data. Used in step calculation, default is 60.
 
-`IRONDB_GRAPHITE_ADJUST_STEP_URL` - url to `graphite_adjust_step.json` file. If present - metrics will be grouped during retrieve phase by step parameter, so, IronDB would return preper results. If empty or not retrieavable
-then grouping functionality will be disabled.
+`IRONDB_GRAPHITE_ADJUST_STEP_URL` - URL to `graphite_adjust_step.json` file. If it is present then metrics will be grouped during retrieve phase by step parameter, so, IronDB would return proper results. If empty or not retrievable then grouping functionality will be disabled.
 
-`IRONDB_GRAPHITE_ADJUST_STEP_URL_TTL` - number of seconds to cache content of retrieved `graphite_adjust_step.json` file. Default is 900 (15 munutes). If refresh attempt is unsuccessful it will disable grouping functionality until next successful retrieve attepmpt.
+`IRONDB_GRAPHITE_ADJUST_STEP_URL_TTL` - the number of seconds to cache content of retrieved `graphite_adjust_step.json` file. Default is 900 (15 minutes). If the refresh attempt is unsuccessful, it will disable grouping functionality until next successful retrieve attempt.
 
 `IRONDB_USE_ACTIVITY_TRACKING` is an optional Python boolean (True|False)
 and will default to True. IRONdb supports tracking of metric activity without

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -370,6 +370,7 @@ class IRONdbMeasurementFetcher(object):
             self.lock.acquire()
             # recheck in case we were waiting
             if (self.fetched == False):
+                log.debug("- gas is {}".format(self.gas))
                 params = {}
                 params['names'] = self.leaves
                 params['start'] = start_time
@@ -469,7 +470,7 @@ class IRONdbFinder(BaseFinder):
                  'connection_timeout', 'headers', 'disabled', 'max_retries',
                  'query_log_enabled', 'zipkin_enabled',
                  'zipkin_event_trace_level', 'max_step', 'min_rollup_span',
-                 'gas','gas_ttl')
+                 'gas','gas_url','gas_ttl')
 
     def __init__(self, config=None):
         global urls
@@ -495,8 +496,8 @@ class IRONdbFinder(BaseFinder):
             self.max_step = None
             self.min_rollup_span = 60
             self.calculate_step_from_target = False
-            self.gas_enabled = False
             self.gas = OrderedDict()
+            self.gas_url = ''
             self.gas_ttl = 900
         else:
             IRONdbLocalSettings.load(self)
@@ -514,7 +515,7 @@ class IRONdbFinder(BaseFinder):
 
     def newfetcher(self, fset, headers):
         fetcher = IRONdbMeasurementFetcher(headers, self.timeout, self.connection_timeout, self.database_rollups, self.rollup_window, self.max_retries,
-                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span, self.gas)
+                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span, self.gas, self.gas_url, self.gas_ttl)
         fset.append(fetcher)
         return fetcher
 
@@ -744,7 +745,7 @@ class IRONdbFinder(BaseFinder):
         measurement_headers = copy.deepcopy(self.headers)
         measurement_headers['Accept'] = 'application/x-flatbuffer-metric-get-result-list'
         fetcher = IRONdbMeasurementFetcher(measurement_headers, self.timeout, self.connection_timeout, self.database_rollups, self.rollup_window, self.max_retries,
-                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span, self.gas)
+                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span, self.gas, self.gas_url, self.gas_ttl)
 
         for name in names:
             if 'leaf' in name and 'leaf_data' in name:

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -282,7 +282,7 @@ class IRONdbLocalSettings(object):
             self.min_rollup_span = 60  # seconds
         try:
             self.gas_url = getattr(settings, 'IRONDB_GRAPHITE_ADJUST_STEP_URL')
-            self.gas = retrieve_gas(gas_url, self.connection_timeout, self.timeout)
+            self.gas = retrieve_gas(self.gas_url, self.connection_timeout, self.timeout)
         except AttributeError:
             self.gas_url = ''
             self.gas = OrderedDict()  # empty dict


### PR DESCRIPTION
Issue: If IronDB has `graphite_adjust_step` plugin enabled then `series_multi` API accepts only `step` parameter if it's match with metric step defined by plugin otherwise return 404. So, we need to group metrics by step, request them from api separately and merge results.
So, this PR implements that idea. It brings 2 new parameters - `IRONDB_GRAPHITE_ADJUST_STEP_URL` - url for `graphite_adjust_step.json` file (empty by default) and `IRONDB_GRAPHITE_ADJUST_STEP_URL_TTL`  - TTL for caching this file (900 seconds by default). If URL is empty or not retrievable - then we assuming that `graphite_adjust_step` plugin is not in use.
Then during initialization plugin retrieves `graphite_adjust_step.json` and store it in parsed form.
During `fetch` function we're 
1) checking if is parsed version of  `graphite_adjust_step` not expired, retrieve new version otherwise
2) loop over all metrics and storing them in separate buckets, together with step. If URL is empty then we just putting all metrics in single bucket
3) looping over buckets, retrieving results and merging them
