### PR TITLE
Fix for graphite_adjust_step processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ case you will get the proper result of aggregating functions even if database ro
 
 `IRONDB_MIN_ROLLUP_SPAN` minimal rollup span for irondb data. Used in step calculation, default is 60.
 
-`IRONDB_GRAPHITE_ADJUST_STEP_URL` - URL to `graphite_adjust_step.json` file. If it is present then metrics will be grouped during retrieve phase by step parameter, so, IronDB would return proper results. If empty or not retrievable then grouping functionality will be disabled.
+`IRONDB_GRAPHITE_ADJUST_STEP_URL` - URL to `graphite_adjust_step.json` file. If it is present then metrics will be grouped during retrieve phase by step parameter, so, IronDB would return proper results. If empty or not retrievable, then grouping functionality will be disabled. Can be absolute URL or relative to `IRONDB_URL` (if not starting with "http"). I.e., if `IRONDB_URL` is "http://host/graphite/userid/" then if `graphite_adjust_step.json` is serving from "http://host/graphite_adjust_step.json" then `IRONDB_GRAPHITE_ADJUST_STEP_URL` should be "../../graphite_adjust_step.json".  Also, in case of multiple URLs in `IRONDB_URL` file will be loaded from every URL in round-robin fashion, same as API calls.
 
 `IRONDB_GRAPHITE_ADJUST_STEP_URL_TTL` - the number of seconds to cache content of retrieved `graphite_adjust_step.json` file. Default is 900 (15 minutes). If the refresh attempt is unsuccessful, it will disable grouping functionality until next successful retrieve attempt.
 

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -329,10 +329,10 @@ class IRONdbLocalSettings(object):
 
 class IRONdbMeasurementFetcher(object):
     __slots__ = ('leaves','lock', 'fetched', 'results', 'headers', 'database_rollups', 'rollup_window', 'timeout', 'connection_timeout', 'retries',
-                 'zipkin_enabled', 'zipkin_event_trace_level', 'max_step', 'min_rollup_span', 'gas', 'gas_url', 'gas_ttl')
+                 'zipkin_enabled', 'zipkin_event_trace_level', 'max_step', 'min_rollup_span')
 
     def __init__(self, headers, timeout, connection_timeout, db_rollups, rollup_window, retries, zipkin_enabled, 
-                zipkin_event_trace_level, max_step, min_rollup_span, gas, gas_url, gas_ttl):
+                zipkin_event_trace_level, max_step, min_rollup_span):
         self.leaves = list()
         self.lock = threading.Lock()
         self.fetched = False
@@ -349,127 +349,82 @@ class IRONdbMeasurementFetcher(object):
         self.max_step = max_step
         if headers:
             self.headers = headers
-        self.gas = gas
-        self.gas_url = gas_url
-        self.gas_ttl = gas_ttl
 
     def add_leaf(self, leaf_name, leaf_data):
         self.leaves.append({'leaf_name': leaf_name, 'leaf_data': leaf_data})
 
     def fetch(self, query_log, start_time, end_time):
-        global gas_next_update
         if (len(self.leaves) == 0):
             # nothing to fetch, we're done
             return
         if (self.fetched == False):
             self.lock.acquire()
-            # update graphite_adjust_step.json if url defined
-            if self.gas_url and gas_next_update <= int(time.time()):
-                self.gas = retrieve_gas(self.gas_url, self.connection_timeout, self.timeout)
-                gas_next_update = int(time.time()) + self.gas_ttl
             # recheck in case we were waiting
             if (self.fetched == False):
-                log.debug(" - gas is {}".format(str(self.gas)))
-                # special dict for storing steps together with leaves
-                gas_steps = {}
-                # if we have gas populated and url defined
-                if self.gas_url and self.gas:
-                    # loop over leaves and group them in gas_steps dict
-                    for leaf in self.leaves:
-                        step = None
-                        for rex in self.gas:
-                            # it's O(N^2) but I doubt we can optimize it
-                            # you need to check all names against all regexes
-                            # from top to bottom until first match
-                            if rex.search(leaf['leaf_name']):
-                                step = self.gas[rex]
-                                break
-                        # if we find match - append leaf to list bound to step in dict
-                        # otherwise put in default (None) bucket
-                        if isinstance(gas_steps.get(step), list):
-                            gas_steps[step].append(leaf)
-                        else:
-                            gas_steps[step] = []
-                            gas_steps[step].append(leaf)
-                else:
-                    # just put all leaves in single batch for retrieval
-                    gas_steps[self.max_step] = self.leaves
-                log.debug(" - gas_steps is {}".format(gas_steps)) 
-                # loop over gas_steps dict
                 params = {}
-                for step in gas_steps:
-                    leaves = gas_steps[step]
-                    if step:
-                        params['step'] = step  
-                    params['names'] = leaves
-                    params['start'] = start_time
-                    params['end'] = end_time
-                    now = int(time.time())
-                    if start_time < (now - self.rollup_window):
-                        params['database_rollups'] = True
-                    else:
-                        params['database_rollups'] = self.database_rollups
-                    for i in range(0, self.retries):
-                        try:
-                            self.fetched = False
-                            query_start = time.gmtime()
-                            node = urls.series_multi
-                            send_headers = copy.deepcopy(self.headers)
-                            if self.zipkin_enabled == True:
-                                traceheader = binascii.hexlify(os.urandom(8))
-                                send_headers['X-B3-TraceId'] = traceheader
-                                send_headers['X-B3-SpanId'] = traceheader
-                                if self.zipkin_event_trace_level == 1:
-                                    send_headers['X-Mtev-Trace-Event'] = '1'
-                                elif self.zipkin_event_trace_level == 2:
-                                    send_headers['X-Mtev-Trace-Event'] = '2'     
-                            log.debug(" - params is {}".format(params))        
-                            d = requests.post(urls.series_multi, json = params, headers = send_headers,
-                                            timeout=((self.connection_timeout / 1000.0), (self.timeout / 1000.0)))
-                            d.raise_for_status()
-                            if 'content-type' in d.headers and d.headers['content-type'] == 'application/x-flatbuffer-metric-get-result-list':
-                                results = irondb_flatbuf.metric_get_results(d.content)
-                                data_type = "flatbuffer"
-                            else:
-                                results = d.json()
-                                data_type = "json"
-                            result_count = len(results["series"]) if results else -1
-                            query_type = "rollup data" if params["database_rollups"] else "raw data"
-                            query_log.query_log(node, query_start, d.elapsed, result_count, json.dumps(params), query_type, data_type, start_time, end_time)
-                            #log.debug(" - before results is {}, self.results is {}".format(results,self.results))
-                            if not self.results:
-                                self.results.update(results)
-                            else:
-                                # merge series dict
-                                if results.get('series'):
-                                    self.results.get('series').update(results.get('series'))
-                            #log.debug(" - after results is {}, self.results is {}".format(results,self.results))
-                            break
-                        except (socket.gaierror, requests.exceptions.ConnectionError) as ex:
-                            # on down nodes, retry on another up to "tries" times
-                            log.exception("IRONdbMeasurementFetcher.fetch ConnectionError %s" % ex)
-                        except requests.exceptions.ConnectTimeout as ex:
-                            # on down nodes, retry on another up to "tries" times
-                            log.exception("IRONdbMeasurementFetcher.fetch ConnectTimeout %s" % ex)
-                        except irondb_flatbuf.FlatBufferError as ex:
-                            # flatbuffer error, try again
-                            log.exception("IRONdbMeasurementFetcher.fetch FlatBufferError %s" % ex)
-                        except JSONDecodeError as ex:
-                            # json error, try again
-                            log.exception("IRONdbMeasurementFetcher.fetch JSONDecodeError %s" % ex)
-                        except requests.exceptions.ReadTimeout as ex:
-                            # on down nodes, retry on another up to "tries" times
-                            log.exception("IRONdbMeasurementFetcher.fetch ReadTimeout %s" % ex)
-                        except requests.exceptions.HTTPError as ex:
-                            # http status code errors are failures, stop immediately
-                            log.exception("IRONdbMeasurementFetcher.fetch HTTPError %s %s" % (ex, d.content))
-                            break
-                result_count = len(self.results["series"]) if self.results else -1
-                if result_count >= 0:
-                    self.fetched = True
-                if settings.DEBUG:
-                    log.debug("IRONdbMeasurementFetcher.fetch results: %s" % json.dumps(self.results))
-                self.lock.release()
+                params['names'] = self.leaves
+                params['start'] = start_time
+                params['end'] = end_time
+                now = int(time.time())
+                if start_time < (now - self.rollup_window):
+                    params['database_rollups'] = True
+                else:
+                    params['database_rollups'] = self.database_rollups
+                for i in range(0, self.retries):
+                    try:
+                        self.fetched = False
+                        query_start = time.gmtime()
+                        node = urls.series_multi
+                        data_type = "json"
+                        send_headers = copy.deepcopy(self.headers)
+                        if self.zipkin_enabled == True:
+                            traceheader = binascii.hexlify(os.urandom(8))
+                            send_headers['X-B3-TraceId'] = traceheader
+                            send_headers['X-B3-SpanId'] = traceheader
+                            if self.zipkin_event_trace_level == 1:
+                                send_headers['X-Mtev-Trace-Event'] = '1'
+                            elif self.zipkin_event_trace_level == 2:
+                                send_headers['X-Mtev-Trace-Event'] = '2'
+                        if self.max_step:
+                            params['step'] = self.max_step      
+                        log.debug("- params is {}".format(params))        
+                        d = requests.post(urls.series_multi, json = params, headers = send_headers,
+                                          timeout=((self.connection_timeout / 1000.0), (self.timeout / 1000.0)))
+                        d.raise_for_status()
+                        if 'content-type' in d.headers and d.headers['content-type'] == 'application/x-flatbuffer-metric-get-result-list':
+                            self.results = irondb_flatbuf.metric_get_results(d.content)
+                            self.fetched = True
+                            data_type = "flatbuffer"
+                        else:
+                            self.results = d.json()
+                            self.fetched = True
+
+                        result_count = len(self.results["series"]) if self.results else -1
+                        query_type = "rollup data" if params["database_rollups"] else "raw data"
+                        query_log.query_log(node, query_start, d.elapsed, result_count, json.dumps(params), query_type, data_type, start_time, end_time)
+                        break
+                    except (socket.gaierror, requests.exceptions.ConnectionError) as ex:
+                        # on down nodes, retry on another up to "tries" times
+                        log.exception("IRONdbMeasurementFetcher.fetch ConnectionError %s" % ex)
+                    except requests.exceptions.ConnectTimeout as ex:
+                        # on down nodes, retry on another up to "tries" times
+                        log.exception("IRONdbMeasurementFetcher.fetch ConnectTimeout %s" % ex)
+                    except irondb_flatbuf.FlatBufferError as ex:
+                        # flatbuffer error, try again
+                        log.exception("IRONdbMeasurementFetcher.fetch FlatBufferError %s" % ex)
+                    except JSONDecodeError as ex:
+                        # json error, try again
+                        log.exception("IRONdbMeasurementFetcher.fetch JSONDecodeError %s" % ex)
+                    except requests.exceptions.ReadTimeout as ex:
+                        # on down nodes, retry on another up to "tries" times
+                        log.exception("IRONdbMeasurementFetcher.fetch ReadTimeout %s" % ex)
+                    except requests.exceptions.HTTPError as ex:
+                        # http status code errors are failures, stop immediately
+                        log.exception("IRONdbMeasurementFetcher.fetch HTTPError %s %s" % (ex, d.content))
+                        break
+            if settings.DEBUG:
+                log.debug("IRONdbMeasurementFetcher.fetch results: %s" % json.dumps(self.results))
+            self.lock.release()
             
     def is_error(self):
         return self.fetched == False or self.results == None or 'error' in self.results or len(self.results['series']) == 0
@@ -550,7 +505,7 @@ class IRONdbFinder(BaseFinder):
 
     def newfetcher(self, fset, headers):
         fetcher = IRONdbMeasurementFetcher(headers, self.timeout, self.connection_timeout, self.database_rollups, self.rollup_window, self.max_retries,
-                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span, self.gas, self.gas_url, self.gas_ttl)
+                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span)
         fset.append(fetcher)
         return fetcher
 
@@ -659,17 +614,38 @@ class IRONdbFinder(BaseFinder):
 
             all_names[pattern] = names
 
+        # update graphite_adjust_step.json if url defined
+        global gas_next_update
+        if self.gas_url and gas_next_update <= int(time.time()):
+            self.gas = retrieve_gas(self.gas_url, self.connection_timeout, self.timeout)
+            gas_next_update = int(time.time()) + self.gas_ttl
+        log.debug(" - gas is {}".format(str(self.gas)))
+
         measurement_headers = copy.deepcopy(self.headers)
         measurement_headers['Accept'] = 'application/x-flatbuffer-metric-get-result-list'
         in_this_batch = 0
+        new_step = self.max_step
         fset = []
         fetcher = self.newfetcher(fset, measurement_headers)
         for pattern, names in all_names.items():
             for name in names:
                 if 'leaf' in name and 'leaf_data' in name:
-                    if self.batch_size == 0 or in_this_batch >= self.batch_size:
+                    # gas processing
+                    if self.gas_url and self.gas:
+                        for rex in self.gas:
+                            # it's O(N^2) but I doubt we can optimize it
+                            # you need to check all names against all regexes
+                            # from top to bottom until first match
+                            if rex.search(name['name']):
+                                new_step = self.gas[rex]
+                                break
+                    if self.batch_size == 0 or in_this_batch >= self.batch_size or new_step != self.max_step:
+                        # start new batch if step not match, suboptimal
+                        # TODO: maybe we can group them in advance?
                         in_this_batch = 0
+                        self.max_step = new_step
                         fetcher = self.newfetcher(fset, measurement_headers)
+
                     fetcher.add_leaf(name['name'], name['leaf_data'])
                     name['fetcher'] = fetcher
                     in_this_batch += 1
@@ -780,7 +756,7 @@ class IRONdbFinder(BaseFinder):
         measurement_headers = copy.deepcopy(self.headers)
         measurement_headers['Accept'] = 'application/x-flatbuffer-metric-get-result-list'
         fetcher = IRONdbMeasurementFetcher(measurement_headers, self.timeout, self.connection_timeout, self.database_rollups, self.rollup_window, self.max_retries,
-                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span, self.gas, self.gas_url, self.gas_ttl)
+                                           self.zipkin_enabled, self.zipkin_event_trace_level, self.max_step, self.min_rollup_span)
 
         for name in names:
             if 'leaf' in name and 'leaf_data' in name:

--- a/irondb/irondb.py
+++ b/irondb/irondb.py
@@ -55,6 +55,10 @@ def retrieve_gas(url, connection_timeout, timeout):
     or return empty dict if broken or non-retrievable
     """
     gas = OrderedDict()
+    if not url.startswith('http'):
+        # relative url
+        global urls
+        url = '{0}{1}'.format(urls.host, url)
     try:
         # retrieve graphite_adjust_step.json file
         r = requests.get(url, params={}, headers={},
@@ -64,8 +68,7 @@ def retrieve_gas(url, connection_timeout, timeout):
             for line in r.json():
                 rx = re.compile(line['re'])
                 gas[rx] = line['step']
-    # TODO: proper error processing
-    except Exception as ex:
+    except (requests.exceptions.RequestException, re.error, AttributeError) as ex:
         pass
     return gas
 


### PR DESCRIPTION
Looks like my previous [fix](https://github.com/circonus-labs/graphite-irondb/pull/38) not really works, let's try different approach:
  - let's move  graphite_adjust_step processing to finder instead of fetcher (which is more logical)
  - so fetcher is reverting to previous version
  - graphite_adjust_step.json update code also moved to finder
  - also, modifying batch mechanism to cache fetcher instances for specific step and reuse cached fetcher if needed.
 - IRONDB_GRAPHITE_ADJUST_STEP_URL now can be absolute URL or relative to `IRONDB_URL` (if not starting with "http"). I.e., if `IRONDB_URL` is "http://host/graphite/userid/" then if `graphite_adjust_step.json` is serving from "http://host/graphite_adjust_step.json" then `IRONDB_GRAPHITE_ADJUST_STEP_URL` should be "../../graphite_adjust_step.json".  Also, in case of multiple URLs in `IRONDB_URL` file will be loaded from every URL in round-robin fashion, same as API calls. 
